### PR TITLE
Fix MIX_ENV for docs generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           MIX_ENV=dev mix compile
           MIX_ENV=test mix compile
           MIX_ENV=prod mix compile
-          MIX_ENV=prod mix docs
+          MIX_ENV=dev mix docs
 
       - name: Upload Docs
         id: docs


### PR DESCRIPTION
Previously, it was using `MIX_ENV=prod` (like we do for formal publication of `main` in other apps) but this library only installs `ex_doc` for dev.