### PR TITLE
Run CI on main for caching and integrity purposes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -15,6 +19,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container: hexpm/elixir:1.18.3-erlang-27.3.3-debian-bookworm-20250407-slim
+    env:
+      # Avoid accidental recompilations
+      MIX_ENV: test
     steps:
       - name: Install Tools
         run: apt update && apt install --no-install-recommends --yes build-essential git
@@ -39,7 +46,7 @@ jobs:
           mix local.rebar --force
           git config --global --add safe.directory '*'
           mix deps.get
-          MIX_ENV=test mix compile --warnings-as-errors
+          mix compile --warnings-as-errors
           mix test
 
       - name: Publish Results
@@ -53,6 +60,9 @@ jobs:
     name: Style
     runs-on: ubuntu-latest
     container: hexpm/elixir:1.18.3-erlang-27.3.3-debian-bookworm-20250407-slim
+    env:
+      # Avoid accidental recompilations
+      MIX_ENV: test
     steps:
       - name: Install Tools
         run: apt update && apt install --no-install-recommends --yes build-essential git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Cache & Docs
+name: Docs
 
 on:
   push:
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cache:
-    name: "Cache"
+  build_docs:
+    name: "Build Docs"
     outputs:
       page_url: ${{ steps.docs.outputs.page_url }}
     runs-on: ubuntu-latest
@@ -40,10 +40,7 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get
-          MIX_ENV=dev mix compile
-          MIX_ENV=test mix compile
-          MIX_ENV=prod mix compile
-          MIX_ENV=dev mix docs
+          MIX_ENV=TEST mix docs
 
       - name: Upload Docs
         id: docs
@@ -52,8 +49,8 @@ jobs:
           path: doc/
 
   docs:
-    name: "Docs"
-    needs: cache
+    name: "Publish Docs"
+    needs: build_docs
     permissions:
       pages: write
       id-token: write

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,8 @@ defmodule Together.MixProject do
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ecto, "~> 3.5", optional: true},
-      {:ex_doc, "~> 0.38", only: [:dev], runtime: false}
+      # Available in `test` to avoid recompilation in CI just for docs
+      {:ex_doc, "~> 0.38", only: [:dev, :test], runtime: false}
     ]
   end
 


### PR DESCRIPTION
Allows us to cut down on the "Cache" compiles and well, now that one is more like publishing docs.